### PR TITLE
Integrate player controls into header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import './index.css'
 import Header from './components/Header'
 import TrackList from './components/TrackList'
-import PlayerControls from './components/PlayerControls'
 import { tracks } from './data/tracks'
 
 
@@ -66,9 +65,6 @@ function App() {
           // Show artist smaller (optional)
           artist={currentTrack.artist}
           cover={currentTrack.cover}
-        />
-
-        <PlayerControls
           isPlaying={isPlaying}
           onToggle={toggle}
           onNext={next}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
-import { FaPlay } from 'react-icons/fa'
 import FollowButton from './FollowButton'
+import { PrevButton, PlayPauseButton, NextButton } from './PlayerControls'
 
-function Header({ title, artist, cover }) {
+function Header({ title, artist, cover, isPlaying, onToggle, onNext, onPrev }) {
   return (
     <header className="flex items-center gap-8 bg-gradient-to-r from-purple-600 to-purple-900 text-white rounded-xl p-6 sm:p-10 mb-10">
       <img
@@ -15,12 +15,9 @@ function Header({ title, artist, cover }) {
         <p className="text-xs text-white/70">661,250 monthly listeners</p>
         <div className="flex items-center gap-4 mt-4">
           <FollowButton />
-          <button
-            className="bg-purple-500 w-12 h-12 rounded-full flex items-center justify-center hover:scale-105 transition"
-            aria-label="Play"
-          >
-            <FaPlay />
-          </button>
+          <PrevButton onPrev={onPrev} />
+          <PlayPauseButton isPlaying={isPlaying} onToggle={onToggle} />
+          <NextButton onNext={onNext} />
         </div>
       </div>
     </header>

--- a/src/components/PlayerControls.jsx
+++ b/src/components/PlayerControls.jsx
@@ -1,33 +1,37 @@
 import { FaPlay, FaPause, FaForward, FaBackward } from 'react-icons/fa'
 
-function PlayerControls({ isPlaying, onToggle, onNext, onPrev }) {
+export function PrevButton({ onPrev }) {
   return (
-    <div className="flex justify-center items-center gap-6 mt-8">
-      <button
-        className="text-xl text-white/80 hover:text-white transition"
-        onClick={onPrev}
-        aria-label="Previous"
-      >
-        <FaBackward />
-      </button>
-
-      <button
-        onClick={onToggle}
-        className="bg-purple-500 w-14 h-14 rounded-full text-white text-2xl flex items-center justify-center hover:scale-105 transition"
-        aria-label={isPlaying ? 'Pause' : 'Play'}
-      >
-        {isPlaying ? <FaPause /> : <FaPlay />}
-      </button>
-
-      <button
-        className="text-xl text-white/80 hover:text-white transition"
-        onClick={onNext}
-        aria-label="Next"
-      >
-        <FaForward />
-      </button>
-    </div>
+    <button
+      className="bg-purple-500 w-12 h-12 rounded-full flex items-center justify-center hover:scale-105 transition"
+      onClick={onPrev}
+      aria-label="Previous"
+    >
+      <FaBackward />
+    </button>
   )
 }
 
-export default PlayerControls
+export function PlayPauseButton({ isPlaying, onToggle }) {
+  return (
+    <button
+      onClick={onToggle}
+      className="bg-purple-500 w-12 h-12 rounded-full flex items-center justify-center hover:scale-105 transition"
+      aria-label={isPlaying ? 'Pause' : 'Play'}
+    >
+      {isPlaying ? <FaPause /> : <FaPlay />}
+    </button>
+  )
+}
+
+export function NextButton({ onNext }) {
+  return (
+    <button
+      className="bg-purple-500 w-12 h-12 rounded-full flex items-center justify-center hover:scale-105 transition"
+      onClick={onNext}
+      aria-label="Next"
+    >
+      <FaForward />
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- Simplificar los botones de control del reproductor y exponerlos individualmente.
- Integrar los controles anterior/reproducir/siguiente directamente en el encabezado, junto con el botón Seguir.
- Transferir el estado de reproducción y los controladores de la aplicación al encabezado.

## Testing
- `npm run lint`

